### PR TITLE
fix(dqn): use weight-only loading to avoid Keras 3 Lambda serializati…

### DIFF
--- a/reinforce/dqn/agent.py
+++ b/reinforce/dqn/agent.py
@@ -352,20 +352,11 @@ class RainbowAgent(BaseAgent):
         target_path = Path(f"{path_prefix}_target.keras")
 
         try:
-            self.online_network = tf.keras.models.load_model(
-                online_path,
-                custom_objects={
-                    "NoisyDense": __import__("reinforce.core.network_utils", fromlist=["NoisyDense"]).NoisyDense
-                },
-            )
-            self.target_network = tf.keras.models.load_model(
-                target_path,
-                custom_objects={
-                    "NoisyDense": __import__("reinforce.core.network_utils", fromlist=["NoisyDense"]).NoisyDense
-                },
-            )
+            # ##>: Load weights only to avoid Lambda layer deserialization issues.
+            self.online_network.load_weights(online_path)
+            self.target_network.load_weights(target_path)
             logger.info(f"Rainbow models loaded from {path_prefix}_*.keras")
-        except (OSError, FileNotFoundError, tf.errors.OpError) as exc:
+        except (OSError, FileNotFoundError, tf.errors.OpError, ValueError) as exc:
             logger.warning(f"Error loading models: {exc}")
 
     @property


### PR DESCRIPTION
…on issues

Keras 3 blocks Lambda layer deserialization by default for security. Using load_weights() instead of load_model() bypasses this since the agent already builds a fresh network with correct architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced model loading reliability by improving the initialization process and expanding error handling capabilities. The system now gracefully handles additional failure scenarios, ensuring more stable and fault-tolerant operation during application startup and model restoration procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->